### PR TITLE
Update documentation for TF 12 pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Creates AWS WAFv2 ACL and supports the following
 * Blocking IP Sets
 * Rate limiting IPs
 
+## Terraform Versions
+
+Terraform 0.12. Pin module version to ~> 1.0. Submit pull-requests to terraform012 branch.
 
 ## Usage with CloudFront
 


### PR DESCRIPTION
This PR updates the new terraform012 branch to add documentation around TF 12 version pinning. If approved, my plan is to release a 1.0.0 pinned to TF 12.