### PR TITLE
Relax version contraints to support Terraform 0.14. Update pre-commit hooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         username: $DOCKER_USERNAME
       environment:
       - TEST_RESULTS: /tmp/test-results
-      image: trussworks/circleci:14ed0ecd3ffe99fbae149dfcf51051a5d2dec8e3
+      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
     steps:
     - checkout
     - restore_cache:
@@ -14,19 +14,18 @@ jobs:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
         - go-mod-sources-v1-{{ checksum "go.sum" }}
     - run:
-        command: 'echo ''export PATH=${PATH}:~/go/bin'' >> $BASH_ENV
-
+        command: |
+          echo ''export PATH=${PATH}:~/go/bin'' >> $BASH_ENV
           source $BASH_ENV
-
-          '
         name: Adding go binaries to $PATH
     - run: go get github.com/jstemmer/go-junit-report
     - run:
-        command: "temp_role=$(aws sts assume-role \\\n        --role-arn arn:aws:iam::313564602749:role/circleci\
-          \ \\\n        --role-session-name circleci)\nexport AWS_ACCESS_KEY_ID=$(echo\
-          \ $temp_role | jq .Credentials.AccessKeyId | xargs)\nexport AWS_SECRET_ACCESS_KEY=$(echo\
-          \ $temp_role | jq .Credentials.SecretAccessKey | xargs)\nexport AWS_SESSION_TOKEN=$(echo\
-          \ $temp_role | jq .Credentials.SessionToken | xargs)\nmake test\n"
+        command: |
+          temp_role=$(aws sts assume-role --role-arn arn:aws:iam::313564602749:role/circleci --role-session-name circleci)
+          export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+          export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+          export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+          make test
         name: Assume role, run pre-commit and run terratest
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -38,8 +37,6 @@ jobs:
         - ~/go/pkg/mod
     - store_test_results:
         path: /tmp/test-results/gotest
-references:
-  circleci: trussworks/circleci:14ed0ecd3ffe99fbae149dfcf51051a5d2dec8e3
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.25.0
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 
@@ -40,6 +40,6 @@ repos:
         pass_filenames: false
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.32.2
+    rev: v1.33.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ which is enabled by default in this module. Until AWS supports that rule set, yo
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to ~> 2.0. Submit pull-requests to master branch.
+Terraform 0.13 and newer. Pin module version to ~> 2.0. Submit pull-requests to master branch.
 
 Terraform 0.12. Pin module version to ~> 1.0. Submit pull-requests to terraform012 branch.
 
@@ -82,14 +82,14 @@ module "wafv2" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
-| aws | ~> 3.0 |
+| terraform | >= 0.13.0 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/examples/alb/main.tf
+++ b/examples/alb/main.tf
@@ -40,7 +40,7 @@ module "wafv2" {
 
   ip_sets_rule = [
     {
-      name       = "${var.test_name}"
+      name       = var.test_name
       priority   = 5
       action     = "count"
       ip_set_arn = aws_wafv2_ip_set.ipset.arn

--- a/examples/alb/variables.tf
+++ b/examples/alb/variables.tf
@@ -10,6 +10,6 @@ variable "fixed_response" {
   type = string
 }
 
-variable block_all_ips {
+variable "block_all_ips" {
   type = bool
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_wafv2_web_acl" "main" {
     metric_name                = var.name
   }
 
-  dynamic rule {
+  dynamic "rule" {
     for_each = var.managed_rules
     content {
       name     = rule.value.name
@@ -54,7 +54,7 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  dynamic rule {
+  dynamic "rule" {
     for_each = var.ip_sets_rule
     content {
       name     = rule.value.name
@@ -91,7 +91,7 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  dynamic rule {
+  dynamic "rule" {
     for_each = var.ip_rate_based_rule != null ? [var.ip_rate_based_rule] : []
     content {
       name     = rule.value.name
@@ -129,7 +129,7 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  dynamic rule {
+  dynamic "rule" {
     for_each = [for header_name in var.filtered_header_rule.header_types : {
       priority     = var.filtered_header_rule.priority + index(var.filtered_header_rule.header_types, header_name) + 1
       name         = header_name

--- a/test/terraform_aws_wafv2_test.go
+++ b/test/terraform_aws_wafv2_test.go
@@ -41,7 +41,7 @@ func TestTerraformAwsWafv2Alb(t *testing.T) {
 	// Confirm we can access the ALB
 	AlbDNSName := terraform.Output(t, terraformOptions, "alb_dns_name")
 	url := fmt.Sprintf("http://%s", AlbDNSName)
-	http_helper.HttpGetWithRetry(t, url, nil, 200, fixedResponse, 5, 5*time.Second)
+	http_helper.HttpGetWithRetry(t, url, nil, 200, fixedResponse, 10, 5*time.Second)
 
 	// Apply with rule to block all IP addresses
 	terraformOptions = &terraform.Options{
@@ -59,7 +59,7 @@ func TestTerraformAwsWafv2Alb(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	// Confirm we get blocked by IP sets rule in the WAF
-	http_helper.HttpGetWithRetryWithCustomValidation(t, url, nil, 5, 5*time.Second, func(status int, body string) bool {
+	http_helper.HttpGetWithRetryWithCustomValidation(t, url, nil, 10, 5*time.Second, func(status int, body string) bool {
 		return status == 403
 	})
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
This will allow folks on Terraform 0.14 to use this module by setting the minimal supported Terraform version. This is aligned with [Terraforms best practices around versioning](https://www.terraform.io/docs/configuration/version-constraints.html#terraform-core-and-provider-versions). CI tests will also will be using the same version. Lastly, this PR cleans up the CircleCI config and updates pre-commit hooks.  

Resolves https://github.com/trussworks/terraform-aws-wafv2/issues/26