### PR TITLE
Relax aws provider version for tf012

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 
@@ -40,6 +40,6 @@ repos:
         pass_filenames: false
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.33.0
     hooks:
       - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.32.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ module "wafv2" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = ">= 2.70, < 4.0"
   }
 }


### PR DESCRIPTION
Last one from me for today - another AWS provider constraint relaxation for the Terraform 0.12 branch to allow the use of 2.x and 3.x.

Given the issues & fixes around the docs in https://github.com/trussworks/terraform-aws-alb-web-containers/pull/82, I've pulled in updates to the pre-commit config here too - if you'd rather have that in another PR, let me know.

