### PR TITLE
Remove deprecation notice for AWSManagedRulesAmazonIpReputationList in GovCloud and update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,6 @@ repos:
         pass_filenames: false
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.35.0
+    rev: v1.36.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Creates AWS WAFv2 ACL and supports the following
 * Global IP Rate limiting
 * Custom IP rate limiting for different URLs
 
-**As of 12/2/2020, AWS GovCloud does not support the `AWSManagedRulesAmazonIpReputationList` managed rule set,
-which is enabled by default in this module. Until AWS supports that rule set, you will need to define your own `managed_rules`.**
-
 ## Terraform Versions
 
 Terraform 0.13 and newer. Pin module version to ~> 2.0. Submit pull-requests to master branch.


### PR DESCRIPTION
Resolves https://github.com/trussworks/terraform-aws-wafv2/issues/36