### PR TITLE
Add possibility to use multi vendor managed rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "aws_wafv2_web_acl" "main" {
       statement {
         managed_rule_group_statement {
           name        = rule.value.name
-          vendor_name = "AWS"
+          vendor_name = rule.value.vendor_name
 
           dynamic "excluded_rule" {
             for_each = rule.value.excluded_rules

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@ variable "managed_rules" {
     priority        = number
     override_action = string
     excluded_rules  = list(string)
+    vendor_name     = string
   }))
   description = "List of Managed WAF rules."
   default = [
@@ -22,36 +23,42 @@ variable "managed_rules" {
       priority        = 10
       override_action = "none"
       excluded_rules  = []
+      vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesAmazonIpReputationList",
       priority        = 20
       override_action = "none"
       excluded_rules  = []
+      vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesKnownBadInputsRuleSet",
       priority        = 30
       override_action = "none"
       excluded_rules  = []
+      vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesSQLiRuleSet",
       priority        = 40
       override_action = "none"
       excluded_rules  = []
+      vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesLinuxRuleSet",
       priority        = 50
       override_action = "none"
       excluded_rules  = []
+      vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesUnixRuleSet",
       priority        = 60
       override_action = "none"
       excluded_rules  = []
+      vendor_name     = "AWS"
     }
   ]
 }


### PR DESCRIPTION
### Problem
I need add managed rules from F5 vendor
This module only accepts AWs Managed Rules

### Solution
Add vendor_name attribute to managed_rules variables

### Considerations
This PR have breaking changes. With this PR, the vendor_name attribute is required, and this attribute doesn't exist in module. 

I can change the code to this vendor_name attribute be optional, but for this i need to use the follow experimental feature:  Optional Object Type Attributes

