### PR TITLE
Use validate-tf gha instead of validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   validate:
-    uses: trussworks/shared-actions/.github/workflows/validate.yml@main
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main


### PR DESCRIPTION
## [wafv2 module needs correct validate-tf file rather than validate](https://trello.com/c/ziOQcjCp)

Changes proposed in this pull request:

- what it says on the tin
