### PR TITLE
bump minimum aws provider version to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ module "wafv2" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.0 |
-| aws | >= 3.0 |
+| aws | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| aws | >= 5.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
should've been done in https://github.com/trussworks/terraform-aws-wafv2/pull/116