### PR TITLE
deprecate older terraform versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ module "wafv2" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 1.0 |
 | aws | >= 5.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ Creates AWS WAFv2 ACL and supports the following
 - Global IP Rate limiting
 - Custom IP rate limiting for different URLs
 
-## Terraform Versions
-
-Terraform 0.13 and newer. Pin module version to ~> 2.0. Submit pull-requests to master branch.
-
-Terraform 0.12. Pin module version to ~> 1.0. Submit pull-requests to terraform012 branch.
-
 ## Usage with CloudFront
 
 **Note: The Terraform AWS provider needs to be associated with the us-east-1 region to use with CloudFront.**

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## [Deprecate support for ancient terraform versions in our modules](https://trello.com/c/H27opwG6)

- Modified README
- Set expected terraform version to be equal or greater than Terraform version 1.0