### PR TITLE
New Feature: Support for Custom Response Bodies 

### DIFF
--- a/examples/alb/main.tf
+++ b/examples/alb/main.tf
@@ -27,6 +27,13 @@ module "wafv2" {
   scope         = "REGIONAL"
   associate_alb = true
   alb_arn       = aws_lb.alb.arn
+
+  #enable custom response code
+  custom_block_response_content = {
+    "test-key" = "Your request has been blocked. Please contact the system administrators"
+  }
+  enable_custom_block_response = true
+
   managed_rules = [
     { "name" : "AWSManagedRulesAmazonIpReputationList", "override_action" : "none", "priority" : 1, "vendor_name" : "AWS", "rule_action_override" : [] },
     { "name" : "AWSManagedRulesCommonRuleSet", "override_action" : "none", "priority" : 2, "vendor_name" : "AWS", "rule_action_override" : [{ "name" = "SizeRestrictions_BODY", "action_to_use" = "allow" }] },
@@ -50,10 +57,14 @@ module "wafv2" {
       ip_set_arn = aws_wafv2_ip_set.ipset.arn
     },
     {
-      name       = "block-all-ips"
-      priority   = 6
-      action     = var.enable_block_all_ips ? "block" : "count"
-      ip_set_arn = aws_wafv2_ip_set.block_all_ips.arn
+      name                              = "block-all-ips"
+      priority                          = 6
+      action                            = var.enable_block_all_ips ? "block" : "count"
+      ip_set_arn                        = aws_wafv2_ip_set.block_all_ips.arn
+      enable_block_custom_response      = true
+      response_code                     = 403
+      block_custom_response_content_key = "test-key"
+      enable_block_custom_headers       = false
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,15 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
+  dynamic "custom_response_body" {
+    for_each = var.enable_custom_block_response == true ? [1] : []
+    content {
+      content      = values(var.custom_block_response_content)[0]
+      content_type = "TEXT_PLAIN"
+      key          = keys(var.custom_block_response_content)[0]
+    }
+  }
+
   dynamic "rule" {
     for_each = var.ip_rate_based_rule != null ? [var.ip_rate_based_rule] : []
     content {

--- a/main.tf
+++ b/main.tf
@@ -96,9 +96,18 @@ resource "aws_wafv2_web_acl" "main" {
           for_each = rule.value.action == "block" ? [1] : []
           content {
             dynamic "custom_response" {
-              for_each = rule.value.response_code != 403 ? [1] : []
+              for_each = rule.value.enable_block_custom_response == true ? [1] : []
               content {
-                response_code = rule.value.response_code
+                custom_response_body_key = rule.value.block_custom_response_content_key
+                response_code            = rule.value.response_code
+
+                dynamic "response_header" {
+                  for_each = rule.value.enable_block_custom_headers == true ? [1] : []
+                  content {
+                    name  = rule.value.response_header_name
+                    value = rule.value.response_header_value
+                  }
+                }
               }
             }
           }
@@ -135,9 +144,18 @@ resource "aws_wafv2_web_acl" "main" {
           for_each = rule.value.action == "block" ? [1] : []
           content {
             dynamic "custom_response" {
-              for_each = rule.value.response_code != 403 ? [1] : []
+              for_each = rule.value.enable_block_custom_response == true ? [1] : []
               content {
-                response_code = rule.value.response_code
+                custom_response_body_key = rule.value.block_custom_response_content_key
+                response_code            = rule.value.response_code
+
+                dynamic "response_header" {
+                  for_each = rule.value.enable_block_custom_headers == true ? [1] : []
+                  content {
+                    name  = rule.value.response_header_name
+                    value = rule.value.response_header_value
+                  }
+                }
               }
             }
           }
@@ -180,9 +198,18 @@ resource "aws_wafv2_web_acl" "main" {
           for_each = rule.value.action == "block" ? [1] : []
           content {
             dynamic "custom_response" {
-              for_each = rule.value.response_code != 403 ? [1] : []
+              for_each = rule.value.enable_block_custom_response == true ? [1] : []
               content {
-                response_code = rule.value.response_code
+                custom_response_body_key = rule.value.block_custom_response_content_key
+                response_code            = rule.value.response_code
+
+                dynamic "response_header" {
+                  for_each = rule.value.enable_block_custom_headers == true ? [1] : []
+                  content {
+                    name  = rule.value.response_header_name
+                    value = rule.value.response_header_value
+                  }
+                }
               }
             }
           }

--- a/variables.tf
+++ b/variables.tf
@@ -69,11 +69,14 @@ variable "managed_rules" {
 
 variable "ip_sets_rule" {
   type = list(object({
-    name          = string
-    priority      = number
-    ip_set_arn    = string
-    action        = string
-    response_code = optional(number, 403)
+    name                              = string
+    priority                          = number
+    ip_set_arn                        = string
+    action                            = string
+    response_code                     = optional(number, 403)
+    enable_block_custom_response      = optional(bool, false)
+    enable_block_custom_headers       = optional(bool, false)
+    block_custom_response_content_key = optional(string)
   }))
   description = "A rule to detect web requests coming from particular IP addresses or address ranges."
   default     = []
@@ -81,11 +84,14 @@ variable "ip_sets_rule" {
 
 variable "ip_rate_based_rule" {
   type = object({
-    name          = string
-    priority      = number
-    limit         = number
-    action        = string
-    response_code = optional(number, 403)
+    name                              = string
+    priority                          = number
+    limit                             = number
+    action                            = string
+    response_code                     = optional(number, 403)
+    enable_block_custom_response      = optional(bool, false)
+    enable_block_custom_headers       = optional(bool, false)
+    block_custom_response_content_key = optional(string)
   })
   description = "A rate-based rule tracks the rate of requests for each originating IP address, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any 5-minute time span"
   default     = null
@@ -93,13 +99,16 @@ variable "ip_rate_based_rule" {
 
 variable "ip_rate_url_based_rules" {
   type = list(object({
-    name                  = string
-    priority              = number
-    limit                 = number
-    action                = string
-    response_code         = optional(number, 403)
-    search_string         = string
-    positional_constraint = string
+    name                              = string
+    priority                          = number
+    limit                             = number
+    action                            = string
+    response_code                     = optional(number, 403)
+    search_string                     = string
+    positional_constraint             = string
+    enable_block_custom_response      = optional(bool, false)
+    enable_block_custom_headers       = optional(bool, false)
+    block_custom_response_content_key = optional(string)
   }))
   description = "A rate and url based rules tracks the rate of requests for each originating IP address, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any 5-minute time span"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -169,3 +169,17 @@ variable "default_action" {
   description = "The action to perform if none of the rules contained in the WebACL match."
   default     = "allow"
 }
+
+variable "enable_custom_block_response" {
+  type        = bool
+  description = "This enables custom responses for the block requests"
+  default     = false
+}
+
+variable "custom_block_response_content" {
+  type        = map(string)
+  description = "This enables custom responses for the block requests"
+  default = {
+    "custom-block-response-key" = "This is the response the client will see when they are blocked by WAF"
+  }
+}


### PR DESCRIPTION
In relevance of the changes to https://github.com/trussworks/terraform-aws-wafv2/issues/86 , I am trying to provide preliminary support for custom response bodies for "block" action.

If the maintainers are interesting in accepting this change, I am happy to update it and bring further refinements here, such as adding support for JSON and HTTP type responses and adding support for multiple custom response bodies in the given WAF